### PR TITLE
Fix email confirmation link using config-based App:BaseUrl

### DIFF
--- a/Controllers/AccountController.cs
+++ b/Controllers/AccountController.cs
@@ -89,8 +89,10 @@ namespace Linear_v1.Controllers
 
                 var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
                 var encodedToken = Uri.EscapeDataString(token);
-                var baseUrl = $"{Request.Scheme}://{Request.Host}";
-                var confirmLink = $"{baseUrl}/Account/ConfirmEmail?userId={user.Id}&token={encodedToken}";
+                var config = HttpContext.RequestServices.GetRequiredService<IConfiguration>();
+                var appBaseUrl = config["App:BaseUrl"]?.TrimEnd('/')
+                    ?? $"{Request.Scheme}://{Request.Host}";
+                var confirmLink = $"{appBaseUrl}/Account/ConfirmEmail?userId={user.Id}&token={encodedToken}";
 
                 await _emailService.SendEmailConfirmationAsync(user.Email, user.FullName, confirmLink);
 

--- a/Controllers/Api/AuthApiController.cs
+++ b/Controllers/Api/AuthApiController.cs
@@ -62,8 +62,10 @@ namespace Linear_v1.Controllers.Api
 
             var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
             var encodedToken = Uri.EscapeDataString(token);
-            var baseUrl = $"{Request.Scheme}://{Request.Host}";
-            var confirmLink = $"{baseUrl}/Account/ConfirmEmail?userId={user.Id}&token={encodedToken}";
+            var config = HttpContext.RequestServices.GetRequiredService<IConfiguration>();
+            var appBaseUrl = config["App:BaseUrl"]?.TrimEnd('/')
+                ?? $"{Request.Scheme}://{Request.Host}";
+            var confirmLink = $"{appBaseUrl}/Account/ConfirmEmail?userId={user.Id}&token={encodedToken}";
 
             string message;
             try


### PR DESCRIPTION
Both AccountController and AuthApiController now read App:BaseUrl from config for confirmation link generation, falling back to Request headers. This ensures the correct production URL is used when deployed behind a reverse proxy (e.g. Render) where Request.Scheme/Host may be incorrect.