### PR TITLE
Disable config file watching to fix inotify limit on Render

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -10,7 +10,16 @@ using System.Data;
 // Tell Npgsql to treat all DateTime as UTC globally
 AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
 
-var builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+{
+    Args = args,
+    // Disable config file watching to avoid inotify limit on constrained hosts (e.g. Render free tier)
+    EnvironmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"
+});
+builder.Configuration.Sources
+    .OfType<Microsoft.Extensions.Configuration.FileConfigurationSource>()
+    .ToList()
+    .ForEach(s => s.ReloadOnChange = false);
 
 // Database
 builder.Services.AddDbContext<ApplicationDbContext>(options =>


### PR DESCRIPTION
Render's free tier hits the OS inotify instance limit (1024) when ASP.NET Core watches appsettings.json for changes. Disabling ReloadOnChange on all FileConfigurationSources fixes the crash.